### PR TITLE
tone: use /frp as /persistent partition

### DIFF
--- a/rootdir/fstab.tone
+++ b/rootdir/fstab.tone
@@ -7,7 +7,7 @@
 /dev/block/bootdevice/by-name/userdata     /data        ext4    noatime,nosuid,nodev,barrier=1,data=ordered,nomblk_io_submit,noauto_da_alloc,discard,errors=panic wait,check,formattable,encryptable=footer
 /dev/block/bootdevice/by-name/boot         /boot        emmc    defaults                                                      defaults
 /dev/block/bootdevice/by-name/FOTAKernel   /recovery    emmc    defaults                                                      defaults
-/dev/block/bootdevice/by-name/config       /persistent  emmc    defaults                                                      defaults
+/dev/block/bootdevice/by-name/frp          /persistent  emmc    defaults                                                      defaults
 /dev/block/bootdevice/by-name/apps_log     /misc        emmc    defaults                                                      defaults
 /dev/block/bootdevice/by-name/modem        /firmware    vfat    ro,shortname=lower,uid=1000,gid=1000,dmask=227,fmask=337,context=u:object_r:firmware_file:s0 wait
 /dev/block/bootdevice/by-name/persist      /persist     ext4    nosuid,nodev,barrier=1,data=ordered,nodelalloc,nomblk_io_submit,errors=panic wait,notrim


### PR DESCRIPTION
change it because there is not /config partition in msm8996 ( check with F8131 - dora )
use /frp for it
              259        8        512 mmcblk0p40

Signed-off-by: David Viteri <davidteri91@gmail.com>