### PR TITLE
tone: fix CPUSETS for quad-core platform

### DIFF
--- a/rootdir/init.tone.rc
+++ b/rootdir/init.tone.rc
@@ -52,17 +52,26 @@ on boot
     # Socket location for RIDL
     mkdir /dev/socket/RIDL 2770 system system
 
-    # Update foreground cpuset now that processors are up
-    write /dev/cpuset/foreground/cpus 0-5
-    write /dev/cpuset/foreground/boost/cpus 4-5
+    # add a cpuset for the camera daemon
+    mkdir /dev/cpuset/camera-daemon
+    write /dev/cpuset/camera-daemon/cpus 0
+    write /dev/cpuset/camera-daemon/mems 0
+    chown system system /dev/cpuset/camera-daemon
+    chown system system /dev/cpuset/camera-daemon/tasks
+    chmod 0664 /dev/cpuset/camera-daemon/tasks
+
+    # update foreground cpuset now that processors are up
+    write /dev/cpuset/foreground/cpus 0-3
+    write /dev/cpuset/foreground/boost/cpus 0-3
     write /dev/cpuset/background/cpus 0
-    write /dev/cpuset/system-background/cpus 0-3
+    write /dev/cpuset/system-background/cpus 0-1
 
 # OSS WLAN and BT MAC setup
 service macaddrsetup /system/bin/macaddrsetup
     user root
     disabled
     oneshot
+    writepid /dev/cpuset/system-background/tasks
 
 service wpa_supplicant /system/bin/wpa_supplicant \
     -iwlan0 -Dnl80211 -c/data/misc/wifi/wpa_supplicant.conf \
@@ -97,6 +106,7 @@ service per_mgr /system/vendor/bin/pm-service
     class core
     user system
     group system net_raw
+    writepid /dev/cpuset/system-background/tasks
 
 # QCOM prop
 service per_proxy /system/vendor/bin/pm-proxy
@@ -104,12 +114,14 @@ service per_proxy /system/vendor/bin/pm-proxy
     user system
     group system net_raw
     disabled
+    writepid /dev/cpuset/system-background/tasks
 
 # Fingerprint service
 service fingerprintd /system/bin/fingerprintd
     class late_start
     user system
     group input
+    writepid /dev/cpuset/system-background/tasks
 
 service msm_irqbalance /system/vendor/bin/msm_irqbalance -f /system/etc/msm_irqbalance.conf
     socket msm_irqbalance seqpacket 660 root system
@@ -123,6 +135,7 @@ service uim /system/bin/brcm-uim-sysfs
     class late_start
     user root
     group bluetooth net_bt_admin net_bt
+    writepid /dev/cpuset/system-background/tasks
 
 on property:vold.post_fs_data_done=1
     # Generate Bluetooth MAC address file only when /data is ready


### PR DESCRIPTION
this can be regulated when AOSP kernel is up

fixing this for don't use wrong CPUs

Signed-off-by: David Viteri <davidteri91@gmail.com>