### PR TITLE
tone: remove caf & somc decoders

### DIFF
--- a/rootdir/system/etc/media_codecs.xml
+++ b/rootdir/system/etc/media_codecs.xml
@@ -123,9 +123,6 @@ Only the three quirks included above are recognized at this point:
         <Setting name="max-video-encoder-input-buffers" value="11" />
     </Settings>
     <Encoders>
-        <!-- Audio Hardware  -->
-        <!-- Audio Software  -->
-        <!-- Video Hardware  -->
         <MediaCodec name="OMX.qcom.video.encoder.avc" type="video/avc" >
             <Quirk name="requires-allocate-on-input-ports" />
             <Quirk name="requires-allocate-on-output-ports" />
@@ -137,7 +134,6 @@ Only the three quirks included above are recognized at this point:
             <Limit name="bitrate" range="1-100000000" />
             <Limit name="frame-rate" range="1-240" />
             <Limit name="concurrent-instances" max="16" />
-          <!-- vt-version, upper 16 bit major version lower 16 bit minor version -->
             <Limit name="vt-version" value="65536" />
             <Limit name="vt-low-latency" value="1" />
             <Limit name="vt-max-instances" value="16" />
@@ -202,7 +198,6 @@ Only the three quirks included above are recognized at this point:
         </MediaCodec>
     </Encoders>
     <Decoders>
-       <!-- Video Hardware  -->
         <MediaCodec name="OMX.qcom.video.decoder.avc" type="video/avc" >
             <Quirk name="requires-allocate-on-input-ports" />
             <Quirk name="requires-allocate-on-output-ports" />
@@ -319,12 +314,6 @@ Only the three quirks included above are recognized at this point:
             <Feature name="secure-playback" required="true" />
             <Limit name="concurrent-instances" max="6" />
         </MediaCodec>
-        <!-- Audio Software  -->
-        <MediaCodec name="OMX.somc.alac.decoder" type="audio/alac" >
-            <Limit name="channel-count" max="6" />
-            <Limit name="sample-rate" ranges="8000,16000,22050,24000,32000,44100,48000,88200,96000,176400,192000" />
-        </MediaCodec>
-        <MediaCodec name="OMX.qti.audio.decoder.flac" type="audio/flac" />
     </Decoders>
     <Include href="media_codecs_google_video.xml" />
 </MediaCodecs>


### PR DESCRIPTION
not used in aosp

Signed-off-by: David Viteri davidteri91@gmail.com
