### PR TITLE
macaddr: remove dangerous sepolicy permissions

### DIFF
--- a/rootdir/init.tone.rc
+++ b/rootdir/init.tone.rc
@@ -26,6 +26,9 @@ on fs
     write /sys/kernel/boot_adsp/boot 1
 
 on boot
+    # Bluetooth
+    chown system system /sys/devices/soc/soc:bcmdhd_wlan/macaddr
+
     # Cover mode
     chown system system /sys/devices/virtual/input/clearpad/cover_mode_enabled
     chown system system /sys/devices/virtual/input/clearpad/cover_win_bottom
@@ -67,8 +70,10 @@ on boot
     write /dev/cpuset/system-background/cpus 0-1
 
 # OSS WLAN and BT MAC setup
-service macaddrsetup /system/bin/macaddrsetup
-    user root
+service macaddrsetup /system/bin/macaddrsetup /sys/devices/soc/soc:bcmdhd_wlan/macaddr
+    class core
+    user system
+    group system bluetooth
     disabled
     oneshot
     writepid /dev/cpuset/system-background/tasks
@@ -140,9 +145,6 @@ service uim /system/bin/brcm-uim-sysfs
 on property:vold.post_fs_data_done=1
     # Generate Bluetooth MAC address file only when /data is ready
     start macaddrsetup
-    # Wait for the file to be created by macaddrsetup
-    wait /data/etc/bluetooth_bdaddr
-    chown bluetooth bluetooth /data/etc/bluetooth_bdaddr
 
 on property:bluetooth.isEnabled=true
     write /sys/class/bluetooth/hci0/idle_timeout 7000


### PR DESCRIPTION
Write the bluetooth macaddr to a place that is natively readable
by bluetooth services, instead of creating new locations which
requires excessive permissions.

tone exclusive edit by Myself5: the macaddr sysfs path is not known yet, so keep the "old lines" but the new ones commented, so once
we know the the path we can just uncomment the proper lines

Signed-off-by: Adam Farden adam@farden.cz
