### PR TITLE
tone: config: Use unique variables for device paths

### DIFF
--- a/PlatformConfig.mk
+++ b/PlatformConfig.mk
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Platform path
+PLATFORM_COMMON_PATH := device/sony/tone
 
 TARGET_BOARD_PLATFORM := msm8996
 
@@ -53,7 +55,7 @@ BOARD_USERDATAIMAGE_PARTITION_SIZE := 22187851776
 BOARD_CACHEIMAGE_PARTITION_SIZE := 268435456
 BOARD_FLASH_BLOCK_SIZE := 131072 # (BOARD_KERNEL_PAGESIZE * 64)
 
-TARGET_RECOVERY_FSTAB = device/sony/tone/rootdir/fstab.tone
+TARGET_RECOVERY_FSTAB = $(PLATFORM_COMMON_PATH)/rootdir/fstab.tone
 
 # Wi-Fi definitions for Broadcom solution
 BOARD_WLAN_DEVICE           := bcmdhd
@@ -67,10 +69,10 @@ WIFI_DRIVER_FW_PATH_AP      := "/vendor/firmware/fw_bcmdhd_apsta.bin"
 WIFI_DRIVER_FW_PATH_STA     := "/vendor/firmware/fw_bcmdhd.bin"
 
 # BT definitions for Broadcom solution
-BOARD_BLUETOOTH_BDROID_BUILDCFG_INCLUDE_DIR := device/sony/tone/bluetooth
+BOARD_BLUETOOTH_BDROID_BUILDCFG_INCLUDE_DIR := $(PLATFORM_COMMON_PATH)/bluetooth
 BOARD_HAVE_BLUETOOTH := true
 BOARD_HAVE_BLUETOOTH_BCM := true
-BOARD_CUSTOM_BT_CONFIG := device/sony/tone/bluetooth/vnd_generic.txt
+BOARD_CUSTOM_BT_CONFIG := $(PLATFORM_COMMON_PATH)/bluetooth/vnd_generic.txt
 
 # RIL
 TARGET_PER_MGR_ENABLED := true
@@ -83,9 +85,9 @@ BOARD_HAVE_ALTERNATE_FM := true
 BOARD_HAVE_BCM_FM := true
 
 # Props for hotplugging
-TARGET_SYSTEM_PROP += device/sony/tone/system.prop
+TARGET_SYSTEM_PROP += $(PLATFORM_COMMON_PATH)/system.prop
 
 # SELinux
-BOARD_SEPOLICY_DIRS += device/sony/tone/sepolicy
+BOARD_SEPOLICY_DIRS += $(PLATFORM_COMMON_PATH)/sepolicy
 
 include device/sony/common/CommonConfig.mk

--- a/platform.mk
+++ b/platform.mk
@@ -12,13 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Platform path
+PLATFORM_COMMON_PATH := device/sony/tone
+
 $(call inherit-product, device/sony/common/common.mk)
 $(call inherit-product, $(SRC_TARGET_DIR)/product/core_64_bit.mk)
 $(call inherit-product, hardware/broadcom/wlan/bcmdhd/config/config-bcm.mk)
 
 SOMC_PLATFORM := tone
 
-SONY_ROOT := device/sony/tone/rootdir
+SONY_ROOT := $(PLATFORM_COMMON_PATH)/rootdir
 
 # Media
 PRODUCT_COPY_FILES += \


### PR DESCRIPTION
 * Avoid hardcoding the paths by using common
    variables declared once for path accesses

Change-Id: I81226a249c6258360c540c80ae4dfe5073439921
Signed-off-by: Adrian DC <radian.dc@gmail.com>