### PR TITLE
system.prop: Tune rqbalance parameters for MSM8996

### DIFF
--- a/system.prop
+++ b/system.prop
@@ -5,11 +5,11 @@
 cpuquiet.low.min_cpus=1
 cpuquiet.low.max_cpus=2
 rqbalance.low.balance_level=80
-rqbalance.low.up_threshold=100 200 300 800 900 4294967295
-rqbalance.low.down_threshold=0 75 175 275 775 875
+rqbalance.low.up_threshold=180 240 400 4294967295 4294967295 4294967295 4294967295 4294967295
+rqbalance.low.down_threshold=0 120 200 330 4294967295 4294967295 4294967295 4294967295
 
 cpuquiet.normal.min_cpus=2
 cpuquiet.normal.max_cpus=4
 rqbalance.normal.balance_level=40
-rqbalance.normal.up_threshold=50 100 150 400 450 4294967295
-rqbalance.normal.down_threshold=0 25 75 125 375 425
+rqbalance.normal.up_threshold=65 145 300 4294967295 4294967295 4294967295 4294967295 4294967295
+rqbalance.normal.down_threshold=0 35 95 160 4294967295 4294967295 4294967295 4294967295


### PR DESCRIPTION
The rqbalance parameters in this file were copied from another device
while early porting: this was wrong (and pretty normal, for that time).
Tune the parameters for a good balance between performance and
battery saving.