### PR TITLE
Adjust device nodes for the brcm BT/FMRadio driver & power handling

### DIFF
--- a/bluetooth/bdroid_buildcfg.h
+++ b/bluetooth/bdroid_buildcfg.h
@@ -40,6 +40,7 @@ static inline const char* getBTDefaultName()
 #define BTM_DEF_LOCAL_NAME getBTDefaultName()
 #endif // OS_GENERIC
 
+#define HCILP_INCLUDED FALSE
 #define BTM_WBS_INCLUDED TRUE
 #define BTIF_HF_WBS_PREFERRED TRUE
 #define BLE_VND_INCLUDED TRUE

--- a/rootdir/system/etc/bluetooth/bt_vendor.conf
+++ b/rootdir/system/etc/bluetooth/bt_vendor.conf
@@ -1,5 +1,11 @@
 # UART device port where Bluetooth controller is attached
-UartPort = /dev/ttyHS0
+# (intrface to libbt)
+UartPort = /dev/brcm_bt_drv
+
+# UART device port of the chip's driver for Uim. UartPort can be
+# a wrapper of this port (e.g., for combined BT/FM chips) used in
+# libbt.
+UimUartPort = /dev/ttyHS0
 
 # Firmware patch file location
 FwPatchFilePath = /system/etc/firmware/


### PR DESCRIPTION
- UartPort is evaluated by libbt (pass BT data to the brcm ldisc driver).
UimUartPort is evaluated by the uim service which needs to be aware of
the uart device node to which the ldisc driver is attached.
Naming aligned with Ie185dcc8aa965b2d4df7dea26adbcc1036c38c6a
- Disable power state handling by libbt as it is done in the brcm driver.

Change-Id: Ifddbc4e3867a62f821a0081312ec441fbe390c49
Signed-off-by: Alexander Diewald <Diewi@diewald-net.com>