### PR TITLE
sony: tone: Fix fstab for aosp 7.1.1

### DIFF
--- a/rootdir/fstab.tone
+++ b/rootdir/fstab.tone
@@ -2,16 +2,16 @@
 # The filesystem that contains the filesystem checker binary (typically /system) cannot
 # specify MF_CHECK, and must come before any filesystems that do specify MF_CHECK
 
-/dev/block/bootdevice/by-name/system       /system      ext4    ro,barrier=1                                                  wait
-/dev/block/bootdevice/by-name/cache        /cache       ext4    noatime,nosuid,nodev,barrier=1,data=ordered,nomblk_io_submit,noauto_da_alloc,errors=panic wait,check,formattable
-/dev/block/bootdevice/by-name/userdata     /data        ext4    noatime,nosuid,nodev,barrier=1,data=ordered,nomblk_io_submit,noauto_da_alloc,discard,errors=panic wait,check,formattable,encryptable=footer
 /dev/block/bootdevice/by-name/boot         /boot        emmc    defaults                                                      defaults
 /dev/block/bootdevice/by-name/FOTAKernel   /recovery    emmc    defaults                                                      defaults
-/dev/block/bootdevice/by-name/frp          /persistent  emmc    defaults                                                      defaults
 /dev/block/bootdevice/by-name/apps_log     /misc        emmc    defaults                                                      defaults
+/dev/block/bootdevice/by-name/frp          /persistent  emmc    defaults                                                      defaults
+/dev/block/bootdevice/by-name/system       /system      ext4    ro,barrier=1,discard                                          wait
+/dev/block/bootdevice/by-name/userdata     /data        ext4    nosuid,nodev,barrier=1,noauto_da_alloc                        wait,check,formattable,encryptable=footer
+/dev/block/bootdevice/by-name/cache        /cache       ext4    nosuid,nodev,barrier=1,discard                                wait,check,formattable
+/dev/block/bootdevice/by-name/persist      /persist     ext4    nosuid,nodev,barrier=1                                        wait,notrim
 /dev/block/bootdevice/by-name/modem        /firmware    vfat    ro,shortname=lower,uid=1000,gid=1000,dmask=227,fmask=337,context=u:object_r:firmware_file:s0 wait
-/dev/block/bootdevice/by-name/persist      /persist     ext4    nosuid,nodev,barrier=1,data=ordered,nodelalloc,nomblk_io_submit,errors=panic wait,notrim
 
-/devices/soc/74a4900.sdhci/mmc_host/mmc*                       auto         auto    nosuid,nodev                              voldmanaged=sdcard1:auto,encryptable=userdata
+/devices/soc/74a4900.sdhci/mmc_host*                           auto         auto    nosuid,nodev                              wait,voldmanaged=sdcard1:auto,encryptable=footer,noemulatedsd
 /devices/soc/6a00000.ssusb/6a00000.dwc3/xhci-hcd.0.auto/usb*   auto         auto    nosuid,nodev                              voldmanaged=usb:auto
 /dev/block/zram0                                               none         swap    defaults                                  zramsize=536870912,notrim


### PR DESCRIPTION
1. Remove/Add mount options based on stock fstab and latest aosp 7.1.1
2. Fix external sdcard mount process.

Signed-off-by: Humberto Borba <humberos@gmail.com>
Change-Id: Ib3faea305048aff57057e0b5ee3e77faa9a142a6