### PR TITLE
[Tone] Scale min CPU bandwidth device based on cpufreq

### DIFF
--- a/rootdir/init.tone.pwr.rc
+++ b/rootdir/init.tone.pwr.rc
@@ -156,3 +156,5 @@ on boot
     write /sys/class/devfreq/soc:qcom,memlat-cpu0/polling_interval 50
     write /sys/class/devfreq/soc:qcom,memlat-cpu2/governor "mem_latency"
     write /sys/class/devfreq/soc:qcom,memlat-cpu2/polling_interval 50
+
+    write /sys/class/devfreq/soc:qcom,mincpubw/governor "cpufreq"


### PR DESCRIPTION
This scales the minimum CPU bandwidth monitoring based
on CPU frequency dictated by cpufreq API.

This allows for generally better bus scaling.