### PR TITLE
[TONE] Use fb triple buffering and enable HWC2

### DIFF
--- a/PlatformConfig.mk
+++ b/PlatformConfig.mk
@@ -82,4 +82,8 @@ TARGET_SYSTEM_PROP += $(PLATFORM_COMMON_PATH)/system.prop
 # SELinux
 BOARD_SEPOLICY_DIRS += $(PLATFORM_COMMON_PATH)/sepolicy
 
+# Display
+NUM_FRAMEBUFFER_SURFACE_BUFFERS := 3
+TARGET_USES_HWC2 := true
+
 include device/sony/common/CommonConfig.mk


### PR DESCRIPTION
Use 3 surface buffers for framebuffer and enable
HWC2 platform-wide to take advantage of the
new non-speculative fences performance.