### PR TITLE
[k4.4 TONE] Configure standard init and recovery for USB ConfigFS

### DIFF
--- a/rootdir/init.recovery.tone.rc
+++ b/rootdir/init.recovery.tone.rc
@@ -1,6 +1,9 @@
+import init.common.usb.rc
+
 on fs
     symlink /dev/block/platform/soc/7464900.sdhci /dev/block/bootdevice
+    setprop sys.usb.controller 6a00000.dwc3
 
 on boot
-    write /sys/class/android_usb/android0/idVendor 0FCE
-    write /sys/class/android_usb/android0/idProduct 6${ro.usb.pid_suffix}
+    setprop sys.usb.config adb
+

--- a/rootdir/init.tone.rc
+++ b/rootdir/init.tone.rc
@@ -26,6 +26,9 @@ on fs
     write /sys/kernel/boot_adsp/boot 1
     write /sys/kernel/boot_slpi/boot 1
 
+    # USB controller setup - required to kickstart ConfigFS
+    setprop sys.usb.controller 6a00000.dwc3
+
 on boot
     # Bluetooth
     chown system system /sys/devices/soc/soc:bcmdhd_wlan/macaddr


### PR DESCRIPTION
The property sys.usb.controller needs to be set for the OS
to know the actual USB class path, relative to the
controller used by the machine.