### PR TITLE
Change the interactive hispeed_freq to 1324800

### DIFF
--- a/rootdir/init.tone.pwr.rc
+++ b/rootdir/init.tone.pwr.rc
@@ -69,7 +69,7 @@ on boot
     write /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor "interactive"
     write /sys/devices/system/cpu/cpu0/cpufreq/interactive/go_hispeed_load 80
     write /sys/devices/system/cpu/cpu0/cpufreq/interactive/timer_rate 20000
-    write /sys/devices/system/cpu/cpu0/cpufreq/interactive/hispeed_freq 1305600
+    write /sys/devices/system/cpu/cpu0/cpufreq/interactive/hispeed_freq 1382400
     write /sys/devices/system/cpu/cpu0/cpufreq/interactive/io_is_busy 0
     write /sys/devices/system/cpu/cpu0/cpufreq/interactive/target_loads "691200:60 806400:80"
     write /sys/devices/system/cpu/cpu0/cpufreq/interactive/min_sample_time 40000


### PR DESCRIPTION
Change the frequency from 1305600 to 1324800
This prevents the following error message in the kernel log:

cpufreq: invalid target_freq: 1305600