### PR TITLE
[master] sony: tone: Increase max number of compression streams

### DIFF
--- a/rootdir/init.tone.rc
+++ b/rootdir/init.tone.rc
@@ -16,6 +16,9 @@ import init.common.rc
 import init.common.usb.rc
 import init.tone.pwr.rc
 
+on init
+    write /sys/block/zram0/max_comp_streams 4
+
 on fs
     symlink /dev/block/platform/soc/7464900.sdhci /dev/block/bootdevice
 


### PR DESCRIPTION
Regardless the value passed to this attribute, ZRAM will always
allocate multiple compression streams - one per online CPUs - thus
allowing several concurrent compression operations. The number of
allocated compression streams goes down when some of the CPUs
become offline. There is no single-compression-stream mode anymore,
unless you are running a UP system or has only 1 CPU online.

Change-Id: I645d22e899735415cc15c821042c4df3b0f169a4
Signed-off-by: Humberto Borba <humberos@gmail.com>