### PR TITLE
Use balanced up_thresholds for video_decoding in rqbalance

### DIFF
--- a/rootdir/system/etc/rqbalance_config.xml
+++ b/rootdir/system/etc/rqbalance_config.xml
@@ -39,8 +39,8 @@
     <video_decoding>
         <cpuquiet min_cpus="1" max_cpus="4"/>
         <rqbalance balance_level="40"/>
-        <rqbalance down_thresholds="0 120 200 330 4294967295 4294967295 4294967295 4294967295"/>
-        <rqbalance   up_thresholds="180 240 400 4294967295 4294967295 4294967295 4294967295 4294967295"/>
+        <rqbalance down_thresholds="0 35 95 160 4294967295 4294967295 4294967295 4294967295"/>
+        <rqbalance   up_thresholds="65 145 300 4294967295 4294967295 4294967295 4294967295 4294967295"/>
     </video_decoding>
 
     <video_encoding>


### PR DESCRIPTION
Otherwise cpu intense applications playing video files suffer from bad performance. E.g. firefox