### PR TITLE
init: tune interactive for power cluster

### DIFF
--- a/rootdir/init.tone.pwr.rc
+++ b/rootdir/init.tone.pwr.rc
@@ -75,11 +75,11 @@ on boot
     write /sys/devices/system/cpu/cpu0/cpufreq/interactive/above_hispeed_delay 19000
     write /sys/devices/system/cpu/cpu0/cpufreq/interactive/use_sched_load 1
     write /sys/devices/system/cpu/cpu0/cpufreq/interactive/use_migration_notif 1
-    write /sys/devices/system/cpu/cpu0/cpufreq/interactive/go_hispeed_load 80
+    write /sys/devices/system/cpu/cpu0/cpufreq/interactive/go_hispeed_load 155
     write /sys/devices/system/cpu/cpu0/cpufreq/interactive/timer_rate 20000
-    write /sys/devices/system/cpu/cpu0/cpufreq/interactive/hispeed_freq 1324800
+    write /sys/devices/system/cpu/cpu0/cpufreq/interactive/hispeed_freq 1228800
     write /sys/devices/system/cpu/cpu0/cpufreq/interactive/io_is_busy 1
-    write /sys/devices/system/cpu/cpu0/cpufreq/interactive/target_loads 80
+    write /sys/devices/system/cpu/cpu0/cpufreq/interactive/target_loads 70 307200:0 729600:52 960000:56 1228800:99
     write /sys/devices/system/cpu/cpu0/cpufreq/interactive/min_sample_time 40000
     write /sys/devices/system/cpu/cpu0/cpufreq/scaling_min_freq 307200
 
@@ -136,8 +136,8 @@ on boot
     write /proc/sys/kernel/sched_enable_thread_grouping 1
 
     # set cpu_boost parameters
-    write /sys/module/cpu_boost/parameters/input_boost_freq "0:1324800"
-    write /sys/module/cpu_boost/parameters/input_boost_ms "80"
+    write /sys/module/cpu_boost/parameters/input_boost_freq "0:1228800"
+    write /sys/module/cpu_boost/parameters/input_boost_ms "20"
 
     # Enable accounting on CPUs hwmon and bus speed decision algos
     # This allows to scale bus frequencies based on bandwidth calc

--- a/rootdir/init.tone.pwr.rc
+++ b/rootdir/init.tone.pwr.rc
@@ -79,7 +79,7 @@ on boot
     write /sys/devices/system/cpu/cpu0/cpufreq/interactive/timer_rate 20000
     write /sys/devices/system/cpu/cpu0/cpufreq/interactive/hispeed_freq 1228800
     write /sys/devices/system/cpu/cpu0/cpufreq/interactive/io_is_busy 1
-    write /sys/devices/system/cpu/cpu0/cpufreq/interactive/target_loads 70 307200:0 729600:52 960000:56 1228800:99
+    write /sys/devices/system/cpu/cpu0/cpufreq/interactive/target_loads "80 1593400:0"
     write /sys/devices/system/cpu/cpu0/cpufreq/interactive/min_sample_time 40000
     write /sys/devices/system/cpu/cpu0/cpufreq/scaling_min_freq 307200
 


### PR DESCRIPTION
I realised that the power cluster  was always stuck on the maximum frequency.
This is ridiculously inefficient, I adjusted the target loads and hispeed frequency to fix this, and its not as aggresive as before.