### PR TITLE
[n-mr1] sony: tone: Add aosp wpa/p2p overlay back

### DIFF
--- a/platform.mk
+++ b/platform.mk
@@ -17,6 +17,7 @@ PLATFORM_COMMON_PATH := device/sony/tone
 
 $(call inherit-product, device/sony/common/common.mk)
 $(call inherit-product, $(SRC_TARGET_DIR)/product/core_64_bit.mk)
+$(call inherit-product, hardware/broadcom/wlan/bcmdhd/config/config-bcm.mk)
 
 SOMC_PLATFORM := tone
 
@@ -46,11 +47,6 @@ PRODUCT_COPY_FILES += \
 # RQBalance-PowerHAL configuration
 PRODUCT_COPY_FILES += \
     $(SONY_ROOT)/system/etc/rqbalance_config.xml:system/etc/rqbalance_config.xml
-
-# WLAN
-PRODUCT_COPY_FILES += \
-    $(SONY_ROOT)/system/etc/p2p_supplicant_overlay.conf:system/etc/wifi/p2p_supplicant_overlay.conf \
-    $(SONY_ROOT)/system/etc/wpa_supplicant_overlay.conf:system/etc/wifi/wpa_supplicant_overlay.conf
 
 # Device Specific Hardware
 PRODUCT_COPY_FILES += \

--- a/rootdir/system/etc/p2p_supplicant_overlay.conf
+++ b/rootdir/system/etc/p2p_supplicant_overlay.conf
@@ -1,4 +1,0 @@
-disable_scan_offload=1
-p2p_no_go_freq=5170-5740
-p2p_search_delay=0
-no_ctrl_interface=

--- a/rootdir/system/etc/wpa_supplicant_overlay.conf
+++ b/rootdir/system/etc/wpa_supplicant_overlay.conf
@@ -1,4 +1,0 @@
-disable_scan_offload=1
-p2p_disabled=1
-filter_rssi=-75
-no_ctrl_interface=


### PR DESCRIPTION
Since kernel was fixed (bcmdhd driver) this overlay is not necessary.

Signed-off-by: Humberto Borba <humberos@gmail.com>
Change-Id: Iba78f608cf8b76bf5a1d21b4fc0e7c8d6d3fb982