### PR TITLE
tone:  fix RFKILL permission (1/2)

### DIFF
--- a/rootdir/ueventd.tone.rc
+++ b/rootdir/ueventd.tone.rc
@@ -113,9 +113,11 @@
 # SSR devices
 /dev/subsys_*         0640   system     system
 
+# Wifi
+/dev/rfkill                                         0660 system    wifi
+
 # BT
 /dev/hidraw*                                        0666 system    system
-/dev/rfkill                                         0660 bluetooth bluetooth
 /dev/ttyHS0                                         0660 bluetooth bluetooth
 /dev/ttyMSM0                                        0660 bluetooth bluetooth
 


### PR DESCRIPTION
fixes the
wpa_supplicant: rfkill: Cannot open RFKILL control device 
error on  wifi start/stop

