### PR TITLE
tone: add sys.usb.rndis.func.name prop

### DIFF
--- a/platform.mk
+++ b/platform.mk
@@ -139,4 +139,5 @@ PRODUCT_PROPERTY_OVERRIDES += \
 
 # USB controller setup
 PRODUCT_PROPERTY_OVERRIDES += \
-    sys.usb.controller=6a00000.dwc3
+    sys.usb.controller=6a00000.dwc3 \
+    sys.usb.rndis.func.name=rndis_bam


### PR DESCRIPTION
needed for USB tethering usecase

Signed-off-by: David Viteri <davidteri91@gmail.com>