### PR TITLE
[TONE] ueventd: Fix for FPC IOCTL implementation

### DIFF
--- a/rootdir/ueventd.tone.rc
+++ b/rootdir/ueventd.tone.rc
@@ -119,6 +119,9 @@
 /dev/ttyHS0                                         0660 bluetooth bluetooth
 /dev/ttyMSM0                                        0660 bluetooth bluetooth
 
+# Fingerprint sensor  device
+/dev/fingerprint          0664 system input
+
 # NFC
 /dev/pn54x                                             0660 nfc nfc
 /sys/devices/soc/75b6000.i2c/i2c-8/8-0028  init_deinit 0200 nfc nfc


### PR DESCRIPTION
Add /dev/fingerprint perms for the new IOCTL implementation.