### PR TITLE
tone: add AOSP's concept of hardware specific genfs contexts

### DIFF
--- a/sepolicy_platform/genfs_contexts
+++ b/sepolicy_platform/genfs_contexts
@@ -1,0 +1,33 @@
+genfscon sysfs /bus/esoc/devices                                        u:object_r:sysfs_msm_subsys:s0
+
+genfscon sysfs /devices/soc/900000.qcom,mdss_mdp                        u:object_r:sysfs_msm_subsys:s0
+genfscon sysfs /devices/soc/900000.qcom,mdss_rotator                    u:object_r:sysfs_msm_subsys:s0
+genfscon sysfs /devices/soc/b00000.qcom,kgsl-3d0                        u:object_r:sysfs_msm_subsys:s0
+genfscon sysfs /devices/soc/9300000.qcom,lpass                          u:object_r:sysfs_msm_subsys:s0
+genfscon sysfs /devices/soc/2080000.qcom,mss                            u:object_r:sysfs_msm_subsys:s0
+genfscon sysfs /devices/soc/400f000.qcom,spmi                           u:object_r:sysfs_msm_subsys:s0
+genfscon sysfs /devices/soc/1c00000.qcom,ssc                            u:object_r:sysfs_msm_subsys:s0
+genfscon sysfs /devices/soc/ce0000.qcom,venus                           u:object_r:sysfs_msm_subsys:s0
+genfscon sysfs /devices/soc/75b6000.i2c                                 u:object_r:sysfs_msm_subsys:s0
+
+genfscon sysfs /devices/soc/a0c000.qcom,cci                             u:object_r:sysfs_camera:s0
+genfscon sysfs /devices/soc/aa4000.qcom,fd                              u:object_r:sysfs_camera:s0
+genfscon sysfs /devices/soc/a1c000.qcom,jpeg                            u:object_r:sysfs_camera:s0
+genfscon sysfs /devices/soc/a24000.qcom,jpeg                            u:object_r:sysfs_camera:s0
+genfscon sysfs /devices/soc/aa0000.qcom,jpeg                            u:object_r:sysfs_camera:s0
+genfscon sysfs /devices/soc/8c0000.qcom,msm-cam                         u:object_r:sysfs_camera:s0
+
+genfscon sysfs /devices/soc/soc:bcm43xx/rfkill/rfkill0/state            u:object_r:sysfs_bluetooth:s0
+genfscon sysfs /devices/soc/soc:bcmdhd_wlan/macaddr                     u:object_r:sysfs_addrsetup:s0
+genfscon sysfs /devices/soc/soc:fpc1145                                 u:object_r:sysfs_fingerprint:s0
+
+genfscon sysfs /devices/soc/900000.qcom,mdss_mdp/caps                   u:object_r:sysfs_mdss_mdp_caps:s0
+genfscon sysfs /module/bcmdhd/parameters/firmware_path                  u:object_r:sysfs_wlan_fwpath:s0
+
+genfscon sysfs /devices/soc/900000.qcom,mdss_mdp/900000.qcom,mdss_mdp:qcom,mdss_fb_primary/leds                       u:object_r:sysfs_leds:s0
+genfscon sysfs /devices/soc/400f000.qcom,spmi/spmi-0/spmi0-03/400f000.qcom,spmi:qcom,pmi8994@3:qcom,leds@d800/leds    u:object_r:sysfs_leds:s0
+genfscon sysfs /devices/soc/400f000.qcom,spmi/spmi-0/spmi0-03/400f000.qcom,spmi:qcom,pmi8994@3:qcom,leds@d000/leds    u:object_r:sysfs_leds:s0
+
+genfscon sysfs /devices/soc/400f000.qcom,spmi/spmi-0/spmi0-02/400f000.qcom,spmi:qcom,pmi8994@2:qcom,fg/power_supply/bms                            u:object_r:sysfs_batteryinfo:s0
+genfscon sysfs /devices/soc/400f000.qcom,spmi/spmi-0/spmi0-02/400f000.qcom,spmi:qcom,pmi8994@2:qcom,fg/power_supply/bms/capacity                   u:object_r:sysfs_batteryinfo:s0
+genfscon sysfs /devices/soc/400f000.qcom,spmi/spmi-0/spmi0-02/400f000.qcom,spmi:qcom,pmi8994@2:qcom,qpnp-smbcharger/power_supply/battery/capacity  u:object_r:sysfs_batteryinfo:s0


### PR DESCRIPTION
following commit https://github.com/sonyxperiadev/device-sony-yoshino/commit/e86a6328c063e1fba04a61490eed732838574269#diff-4fc6aac355aec173fea596908e6691d2