### PR TITLE
[N-MR1] sepolicy: add oem partition

### DIFF
--- a/sepolicy_platform/file_contexts
+++ b/sepolicy_platform/file_contexts
@@ -47,5 +47,8 @@
 /dev/block/platform/soc/7464900\.sdhci/by-name/rdimage         u:object_r:rdimage_block_device:s0
 /dev/block/bootdevice/by-name/rdimage                          u:object_r:rdimage_block_device:s0
 
+/dev/block/platform/soc/7464900\.sdhci/by-name/oem             u:object_r:system_block_device:s0
+/dev/block/bootdevice/by-name/oem                              u:object_r:system_block_device:s0
+
 /dev/block/zram0                                               u:object_r:swap_block_device:s0
 


### PR DESCRIPTION
We use the oem partition to store vendor blobs and we mark the
partition as system_block_device

Signed-off-by: Alin Jerpelea <alin.jerpelea@sonymobile.com>