### PR TITLE
[o-mr0] tone: Fix service path for Android O

### DIFF
--- a/rootdir/init.tone.rc
+++ b/rootdir/init.tone.rc
@@ -86,7 +86,7 @@ on boot
     write /dev/cpuset/system-background/cpus 0-1
 
 # OSS WLAN and BT MAC setup
-service macaddrsetup /system/vendor/bin/macaddrsetup /sys/devices/soc/soc:bcmdhd_wlan/macaddr
+service macaddrsetup /vendor/bin/macaddrsetup /sys/devices/soc/soc:bcmdhd_wlan/macaddr
     class core
     user system
     group system bluetooth
@@ -94,7 +94,7 @@ service macaddrsetup /system/vendor/bin/macaddrsetup /sys/devices/soc/soc:bcmdhd
     oneshot
     writepid /dev/cpuset/system-background/tasks
 
-service wpa_supplicant /system/vendor/bin/hw/wpa_supplicant \
+service wpa_supplicant /vendor/bin/hw/wpa_supplicant \
     -iwlan0 -Dnl80211 -c/data/misc/wifi/wpa_supplicant.conf \
     -I/system/etc/wifi/wpa_supplicant_overlay.conf \
     -e/data/misc/wifi/entropy.bin -g@android:wpa_wlan0


### PR DESCRIPTION
There is a symlink from /vendor to /system/vendor.

Signed-off-by: Pavel Dubrova <pashadubrova@gmail.com>