### PR TITLE
SND_DEVICE_IN_HEADSET_MIC spelling mistake correction

### DIFF
--- a/rootdir/system/etc/audio_platform_info.xml
+++ b/rootdir/system/etc/audio_platform_info.xml
@@ -39,7 +39,7 @@
         <device name="SND_DEVICE_IN_VOICE_DMIC" acdb_id="6"/>
         <device name="SND_DEVICE_IN_SPEAKER_DMIC_AEC_NS" acdb_id="578"/>
         <device name="SND_DEVICE_IN_HANDSET_DMIC_AEC_NS" acdb_id="577"/>
-        <device name="SND_DEVICE_IN_HEADSET_MIC " acdb_id="579"/>
+        <device name="SND_DEVICE_IN_HEADSET_MIC" acdb_id="579"/>
         <!-- Custom mapping ends here -->
     </acdb_ids>
     <bit_width_configs>


### PR DESCRIPTION
ACDB configuration not correctly loaded for SND_DEVICE_IN_HEADSET_MIC
due to spelling mistake.

There are more issues than this to fix VOIP but this is part of it