### PR TITLE
Update HMP configuration for tone platform

### DIFF
--- a/rootdir/vendor/etc/init/init.tone.pwr.rc
+++ b/rootdir/vendor/etc/init/init.tone.pwr.rc
@@ -112,15 +112,16 @@ on property:sys.boot_completed=1
     write /proc/sys/kernel/sched_window_stats_policy 5
     write /proc/sys/kernel/sched_ravg_hist_size 5
 
-    write /proc/sys/kernel/sched_freq_inc_notify 50000
-    write /proc/sys/kernel/sched_freq_dec_notify 50000
+    write /proc/sys/kernel/sched_freq_inc_notify 400000
+    write /proc/sys/kernel/sched_freq_dec_notify 400000
 
     # HMP Task packing settings for 8996
     write /proc/sys/kernel/sched_small_wakee_task_load 30
     write /proc/sys/kernel/sched_boost 0
     #enable sched colocation and colocation inheritance
-    write /proc/sys/kernel/sched_upmigrate 130
-    write /proc/sys/kernel/sched_downmigrate 110
+    write /proc/sys/kernel/sched_migration_fixup 1
+    write /proc/sys/kernel/sched_upmigrate 95
+    write /proc/sys/kernel/sched_downmigrate 90
     write /proc/sys/kernel/sched_enable_thread_grouping 1
 
     # disallow upmigrate for cgroup's tasks

--- a/rootdir/vendor/etc/init/init.tone.pwr.rc
+++ b/rootdir/vendor/etc/init/init.tone.pwr.rc
@@ -127,6 +127,8 @@ on property:sys.boot_completed=1
     # disallow upmigrate for cgroup's tasks
     write /dev/cpuctl/cpu.upmigrate_discourage 1
 
+    write /proc/sys/kernel/sched_init_task_load 100
+
     # Enable accounting on CPUs hwmon and bus speed decision algos
     # This allows to scale bus frequencies based on bandwidth calc
     write /sys/class/devfreq/soc:qcom,cpubw/governor "bw_hwmon"

--- a/rootdir/vendor/etc/init/init.tone.pwr.rc
+++ b/rootdir/vendor/etc/init/init.tone.pwr.rc
@@ -103,8 +103,6 @@ on property:sys.boot_completed=1
 
     # Apply Scheduler and Governor settings for 8996
     # HMP scheduler (big.Little cluster related) settings
-    write /proc/sys/kernel/sched_upmigrate 95
-    write /proc/sys/kernel/sched_downmigrate 85
     write /proc/sys/kernel/sched_group_upmigrate 100
     write /proc/sys/kernel/sched_group_downmigrate 95
     write /proc/sys/kernel/sched_select_prev_cpu_us 0

--- a/rootdir/vendor/etc/init/init.tone.pwr.rc
+++ b/rootdir/vendor/etc/init/init.tone.pwr.rc
@@ -110,7 +110,7 @@ on property:sys.boot_completed=1
     write /proc/sys/kernel/sched_migration_fixup 1
     write /proc/sys/kernel/sched_downmigrate 45
     write /proc/sys/kernel/sched_upmigrate 45
-    write /proc/sys/kernel/sched_init_task_load 100
+    write /proc/sys/kernel/sched_init_task_load 65
 
     # Enable accounting on CPUs hwmon and bus speed decision algos
     # This allows to scale bus frequencies based on bandwidth calc

--- a/rootdir/vendor/etc/init/init.tone.pwr.rc
+++ b/rootdir/vendor/etc/init/init.tone.pwr.rc
@@ -98,6 +98,9 @@ on property:sys.boot_completed=1
     write /sys/module/cpu_boost/parameters/input_boost_freq "0:1324800"
     write /sys/module/cpu_boost/parameters/input_boost_ms "80"
 
+    # set sync wakee policy tunable
+    write /proc/sys/kernel/sched_prefer_sync_wakee_to_waker 1
+
     # Apply Scheduler and Governor settings for 8996
     # HMP scheduler (big.Little cluster related) settings
     write /proc/sys/kernel/sched_upmigrate 95

--- a/rootdir/vendor/etc/init/init.tone.pwr.rc
+++ b/rootdir/vendor/etc/init/init.tone.pwr.rc
@@ -101,32 +101,15 @@ on property:sys.boot_completed=1
     # set sync wakee policy tunable
     write /proc/sys/kernel/sched_prefer_sync_wakee_to_waker 1
 
-    # Apply Scheduler and Governor settings for 8996
-    # HMP scheduler (big.Little cluster related) settings
-    write /proc/sys/kernel/sched_group_upmigrate 100
-    write /proc/sys/kernel/sched_group_downmigrate 95
-    write /proc/sys/kernel/sched_select_prev_cpu_us 0
-    write /proc/sys/kernel/sched_spill_nr_run 5
-    write /proc/sys/kernel/sched_restrict_cluster_spill 1
-
-    write /proc/sys/kernel/sched_window_stats_policy 5
-    write /proc/sys/kernel/sched_ravg_hist_size 5
-
+    write /proc/sys/kernel/sched_spill_nr_run 3
     write /proc/sys/kernel/sched_freq_inc_notify 400000
     write /proc/sys/kernel/sched_freq_dec_notify 400000
 
-    # HMP Task packing settings for 8996
-    write /proc/sys/kernel/sched_small_wakee_task_load 30
+    # Setting b.L scheduler parameters
     write /proc/sys/kernel/sched_boost 0
-    #enable sched colocation and colocation inheritance
     write /proc/sys/kernel/sched_migration_fixup 1
     write /proc/sys/kernel/sched_downmigrate 45
     write /proc/sys/kernel/sched_upmigrate 45
-    write /proc/sys/kernel/sched_enable_thread_grouping 1
-
-    # disallow upmigrate for cgroup's tasks
-    write /dev/cpuctl/cpu.upmigrate_discourage 1
-
     write /proc/sys/kernel/sched_init_task_load 100
 
     # Enable accounting on CPUs hwmon and bus speed decision algos

--- a/rootdir/vendor/etc/init/init.tone.pwr.rc
+++ b/rootdir/vendor/etc/init/init.tone.pwr.rc
@@ -121,7 +121,7 @@ on property:sys.boot_completed=1
     #enable sched colocation and colocation inheritance
     write /proc/sys/kernel/sched_migration_fixup 1
     write /proc/sys/kernel/sched_upmigrate 95
-    write /proc/sys/kernel/sched_downmigrate 90
+    write /proc/sys/kernel/sched_downmigrate 95
     write /proc/sys/kernel/sched_enable_thread_grouping 1
 
     # disallow upmigrate for cgroup's tasks

--- a/rootdir/vendor/etc/init/init.tone.pwr.rc
+++ b/rootdir/vendor/etc/init/init.tone.pwr.rc
@@ -120,8 +120,8 @@ on property:sys.boot_completed=1
     write /proc/sys/kernel/sched_boost 0
     #enable sched colocation and colocation inheritance
     write /proc/sys/kernel/sched_migration_fixup 1
-    write /proc/sys/kernel/sched_upmigrate 95
-    write /proc/sys/kernel/sched_downmigrate 95
+    write /proc/sys/kernel/sched_downmigrate 45
+    write /proc/sys/kernel/sched_upmigrate 45
     write /proc/sys/kernel/sched_enable_thread_grouping 1
 
     # disallow upmigrate for cgroup's tasks


### PR DESCRIPTION
Current configuration is a mix of CAF tuning for msm8956 and msm8998, that have >=6  cores (unlike msm8996 with its 4 cores) what leads to poor performance on this platform. This patchset (except last commit) resets scheduler configuration to CAF one. Even though it is not perfect, it's still better than previous both performance- and battery-wise.

Reference for CAF settings: https://source.codeaurora.org/quic/la/device/qcom/common/tree/rootdir/etc/init.qcom.post_boot.sh?h=LA.UM.6.5.r1-07400-8x96.0
