### PR TITLE
sepolicy: add selinux for kernel 4.9

### DIFF
--- a/sepolicy_platform/genfs_contexts
+++ b/sepolicy_platform/genfs_contexts
@@ -22,6 +22,7 @@ genfscon sysfs /devices/soc/soc:bcmdhd_wlan/macaddr                     u:object
 genfscon sysfs /devices/soc/soc:fpc1145                                 u:object_r:sysfs_fingerprint:s0
 
 genfscon sysfs /devices/soc/900000.qcom,mdss_mdp/caps                   u:object_r:sysfs_mdss_mdp_caps:s0
+genfscon sysfs /devices/platform/soc/900000.qcom,mdss_mdp/caps          u:object_r:sysfs_mdss_mdp_caps:s0
 genfscon sysfs /module/bcmdhd/parameters/firmware_path                  u:object_r:sysfs_wlan_fwpath:s0
 
 genfscon sysfs /devices/soc/900000.qcom,mdss_mdp/900000.qcom,mdss_mdp:qcom,mdss_fb_primary/leds                       u:object_r:sysfs_leds:s0


### PR DESCRIPTION
10-10 12:24:33.456  1171  1171 I android.hardwar: type=1400 audit(0.0:66): avc: denied { open } for path=/sys/devices/platform/soc/900000.qcom,mdss_mdp/caps dev=sysfs ino=36085 scontext=u:r:hal_graphics_composer_default:s0 tcontext=u:object_r:sysfs:s0 tclass=file permissive=1
10-10 12:24:33.456  1171  1171 I android.hardwar: type=1400 audit(0.0:67): avc: denied { getattr } for path=/sys/devices/platform/soc/900000.qcom,mdss_mdp/caps dev=sysfs ino=36085 scontext=u:r:hal_graphics_composer_default:s0 tcontext=u:object_r:sysfs:s0 tclass=file permissive=1
10-10 12:24:43.337  1289  1289 I android.hardwar: type=1400 audit(0.0:73): avc: denied { read } for name=caps dev=sysfs ino=36085 scontext=u:r:hal_graphics_composer_default:s0 tcontext=u:object_r:sysfs:s0 tclass=file permissive=1

Signed-off-by: David Viteri <davidteri91@gmail.com>