### PR TITLE
[master] fstab: Update paths for k4.9

### DIFF
--- a/rootdir/vendor/etc/fstab.tone
+++ b/rootdir/vendor/etc/fstab.tone
@@ -14,6 +14,6 @@
 /dev/block/bootdevice/by-name/modem        /firmware    vfat    ro,shortname=lower,uid=1000,gid=1000,dmask=227,fmask=337,context=u:object_r:firmware_file:s0 wait
 /dev/block/bootdevice/by-name/persist      /persist     ext4    noatime,nosuid,nodev,barrier=1,data=ordered,nodelalloc,errors=panic wait,notrim
 
-/devices/soc/74a4900.sdhci/mmc_host/mmc*                       auto         auto    nosuid,nodev                              voldmanaged=sdcard1:auto
-/devices/soc/6a00000.ssusb/6a00000.dwc3/xhci-hcd.0.auto/usb*   auto         auto    nosuid,nodev                              voldmanaged=usb:auto
-/dev/block/zram0                                               none         swap    defaults                                  zramsize=536870912,notrim
+/devices/platform/soc/74a4900.sdhci/mmc_host/mmc*                       auto         auto    nosuid,nodev                      voldmanaged=sdcard1:auto
+/devices/platform/soc/6a00000.ssusb/6a00000.dwc3/xhci-hcd.0.auto/usb*   auto         auto    nosuid,nodev                      voldmanaged=usb:auto
+/dev/block/zram0                            none        swap    defaults                                                       zramsize=536870912,notrim


### PR DESCRIPTION
On kernel 4.9, /sys/devices/soc has been moved
to /sys/devices/platform/soc.

Signed-off-by: Pavel Dubrova <pashadubrova@gmail.com>