### PR TITLE
label battery/present needed by healthd

### DIFF
--- a/sepolicy_platform/genfs_contexts
+++ b/sepolicy_platform/genfs_contexts
@@ -63,3 +63,4 @@ genfscon sysfs /devices/platform/soc/400f000.qcom,spmi/spmi-0/spmi0-03/400f000.q
 genfscon sysfs /devices/platform/soc/400f000.qcom,spmi/spmi-0/spmi0-02/400f000.qcom,spmi:qcom,pmi8994@2:qcom,fg/power_supply/bms                            u:object_r:sysfs_batteryinfo:s0
 genfscon sysfs /devices/platform/soc/400f000.qcom,spmi/spmi-0/spmi0-02/400f000.qcom,spmi:qcom,pmi8994@2:qcom,fg/power_supply/bms/capacity                   u:object_r:sysfs_batteryinfo:s0
 genfscon sysfs /devices/platform/soc/400f000.qcom,spmi/spmi-0/spmi0-02/400f000.qcom,spmi:qcom,pmi8994@2:qcom,qpnp-smbcharger/power_supply/battery/capacity  u:object_r:sysfs_batteryinfo:s0
+genfscon sysfs /devices/platform/soc/400f000.qcom,spmi/spmi-0/spmi0-02/400f000.qcom,spmi:qcom,pmi8994@2:qcom,qpnp-smbcharger/power_supply/battery/present   u:object_r:sysfs_batteryinfo:s0


### PR DESCRIPTION
09-07 10:50:13.090   549   549 I healthd : type=1400 audit(0.0:150): avc: denied { open } for path=/sys/devices/platform/soc/400f000.qcom,spmi/spmi-0/spmi0-02/400f000.qcom,spmi:pmi8994@2:qcom,qpnp-smbcharger/power_supply/battery/present dev=sysfs ino=42733 scontext=u:r:healthd:s0 tcontext=u:object_r:sysfs_msm_subsys:s0 tclass=file permissive=1
09-07 10:50:13.090   549   549 I healthd : type=1400 audit(0.0:151): avc: denied { getattr } for path=/sys/devices/platform/soc/400f000.qcom,spmi/spmi-0/spmi0-02/400f000.qcom,spmi:pmi8994@2:qcom,qpnp-smbcharger/power_supply/battery/present dev=sysfs ino=42733 scontext=u:r:healthd:s0 tcontext=u:object_r:sysfs_msm_subsys:s0 tclass=file permissive=1

Signed-off-by: David Viteri <davidteri91@gmail.com>