### PR TITLE
label bcl as sysfs_batteryinfo

### DIFF
--- a/sepolicy_platform/genfs_contexts
+++ b/sepolicy_platform/genfs_contexts
@@ -62,5 +62,6 @@ genfscon sysfs /devices/platform/soc/400f000.qcom,spmi/spmi-0/spmi0-03/400f000.q
 genfscon sysfs /devices/platform/soc/400f000.qcom,spmi/spmi-0/spmi0-03/400f000.qcom,spmi:pmi8994@3:qcom,leds@d800/leds         u:object_r:sysfs_leds:s0
 genfscon sysfs /devices/platform/soc/400f000.qcom,spmi/spmi-0/spmi0-03/400f000.qcom,spmi:pmi8994@3:qcom,haptics@c000/leds      u:object_r:sysfs_leds:s0
 
+genfscon sysfs /devices/platform/soc/400f000.qcom,spmi/spmi-0/spmi0-02/400f000.qcom,spmi:pmi8994@2:bcl@4200/power_supply                       u:object_r:sysfs_batteryinfo:s0
 genfscon sysfs /devices/platform/soc/400f000.qcom,spmi/spmi-0/spmi0-02/400f000.qcom,spmi:pmi8994@2:qcom,fg/power_supply                        u:object_r:sysfs_batteryinfo:s0
 genfscon sysfs /devices/platform/soc/400f000.qcom,spmi/spmi-0/spmi0-02/400f000.qcom,spmi:pmi8994@2:qcom,qpnp-smbcharger/power_supply           u:object_r:sysfs_batteryinfo:s0


### PR DESCRIPTION
05-02 08:14:06.950   549   549 I healthd : type=1400 audit(0.0:4): avc: denied { open } for path=/sys/devices/platform/soc/400f000.qcom,spmi/spmi-0/spmi0-02/400f000.qcom,spmi:pmi8994@2:bcl@4200/power_supply/fg_adc/type dev=sysfs ino=43124 scontext=u:r:healthd:s0 tcontext=u:object_r:sysfs_msm_subsys:s0 tclass=file permissive=1
05-02 08:14:06.950   549   549 I healthd : type=1400 audit(0.0:5): avc: denied { getattr } for path=/sys/devices/platform/soc/400f000.qcom,spmi/spmi-0/spmi0-02/400f000.qcom,spmi:pmi8994@2:bcl@4200/power_supply/fg_adc/type dev=sysfs ino=43124 scontext=u:r:healthd:s0 tcontext=u:object_r:sysfs_msm_subsys:s0 tclass=file permissive=1

Signed-off-by: David Viteri <davidteri91@gmail.com>