### PR TITLE
[Ready for merge] Restore LED path conditions

### DIFF
--- a/rootdir/vendor/ueventd.rc
+++ b/rootdir/vendor/ueventd.rc
@@ -130,14 +130,13 @@
 /sys/devices/platform/soc/75b6000.i2c/i2c-8/8-0028  send_cmd    0200 nfc nfc
 
 # LED
-/sys/devices/platform/soc/400f000.qcom,spmi/spmi-0/spmi0-03/400f000.qcom,spmi:qcom,pmi8994@3:qcom,leds@d800/leds/wled brightness      0664 system system
-/sys/devices/platform/soc/400f000.qcom,spmi/spmi-0/spmi0-03/400f000.qcom,spmi:qcom,pmi8994@3:qcom,leds@d800/leds/wled max_brightness  0664 system system
-/sys/devices/platform/soc/400f000.qcom,spmi/spmi-0/spmi0-03/400f000.qcom,spmi:qcom,pmi8994@3:qcom,leds@d000/leds/led:* max_brightness 0664 system system
-/sys/devices/platform/soc/400f000.qcom,spmi/spmi-0/spmi0-03/400f000.qcom,spmi:qcom,pmi8994@3:qcom,leds@d000/leds/led:* brightness     0664 system system
-/sys/devices/platform/soc/400f000.qcom,spmi/spmi-0/spmi0-03/400f000.qcom,spmi:qcom,pmi8994@3:qcom,leds@d000/leds/led:* blink          0664 system system
-/sys/devices/platform/soc/400f000.qcom,spmi/spmi-0/spmi0-03/400f000.qcom,spmi:qcom,pmi8994@3:qcom,leds@d000/leds/led:* duty_pcts      0664 system system
-/sys/devices/platform/soc/400f000.qcom,spmi/spmi-0/spmi0-03/400f000.qcom,spmi:qcom,pmi8994@3:qcom,leds@d000/leds/rgb rgb_blink        0664 system system
-
+/sys/devices/platform/soc/400f000.qcom,spmi/spmi-0/spmi0-03/400f000.qcom,spmi:pmi8994@3:qcom,leds@d800/leds/wled   brightness      0664  system  system
+/sys/devices/platform/soc/400f000.qcom,spmi/spmi-0/spmi0-03/400f000.qcom,spmi:pmi8994@3:qcom,leds@d800/leds/wled   max_brightness  0664  system  system
+/sys/devices/platform/soc/400f000.qcom,spmi/spmi-0/spmi0-03/400f000.qcom,spmi:pmi8994@3:qcom,leds@d000/leds/led:*  max_brightness  0664  system  system
+/sys/devices/platform/soc/400f000.qcom,spmi/spmi-0/spmi0-03/400f000.qcom,spmi:pmi8994@3:qcom,leds@d000/leds/led:*  brightness      0664  system  system
+/sys/devices/platform/soc/400f000.qcom,spmi/spmi-0/spmi0-03/400f000.qcom,spmi:pmi8994@3:qcom,leds@d000/leds/led:*  blink           0664  system  system
+/sys/devices/platform/soc/400f000.qcom,spmi/spmi-0/spmi0-03/400f000.qcom,spmi:pmi8994@3:qcom,leds@d000/leds/led:*  duty_pcts       0664  system  system
+/sys/devices/platform/soc/400f000.qcom,spmi/spmi-0/spmi0-03/400f000.qcom,spmi:pmi8994@3:qcom,leds@d000/leds/rgb    rgb_blink       0664  system  system
 
 # Framebuffer for Dynamic Resolution Switch
 /sys/devices/virtual/graphics/fb0 mode        0664 system graphics


### PR DESCRIPTION
Last two commits broke leds on kagura.
Will trim this down and squash.