### PR TITLE
[TONE] PlatformConfig: Define TARGET_USES_GRALLOC1 for legacy

### DIFF
--- a/PlatformConfig.mk
+++ b/PlatformConfig.mk
@@ -69,6 +69,9 @@ TARGET_PER_MGR_ENABLED := true
 # SELinux
 BOARD_SEPOLICY_DIRS += $(PLATFORM_COMMON_PATH)/sepolicy_platform
 
+# Display
+TARGET_USES_GRALLOC1 := true
+
 # Cache partition
 BOARD_CACHEIMAGE_FILE_SYSTEM_TYPE := ext4
 


### PR DESCRIPTION
This platform uses old Adreno binaries and is not compatible
with the new style gralloc.