### PR TITLE
Add sepolicy context to type-c power_supply

### DIFF
--- a/sepolicy_platform/genfs_contexts
+++ b/sepolicy_platform/genfs_contexts
@@ -34,3 +34,4 @@ genfscon sysfs /devices/platform/soc/400f000.qcom,spmi/spmi-0/spmi0-03/400f000.q
 genfscon sysfs /devices/platform/soc/400f000.qcom,spmi/spmi-0/spmi0-02/400f000.qcom,spmi:pmi8994@2:bcl@4200/power_supply                       u:object_r:sysfs_batteryinfo:s0
 genfscon sysfs /devices/platform/soc/400f000.qcom,spmi/spmi-0/spmi0-02/400f000.qcom,spmi:pmi8994@2:qcom,fg/power_supply                        u:object_r:sysfs_batteryinfo:s0
 genfscon sysfs /devices/platform/soc/400f000.qcom,spmi/spmi-0/spmi0-02/400f000.qcom,spmi:pmi8994@2:qcom,qpnp-smbcharger/power_supply           u:object_r:sysfs_batteryinfo:s0
+genfscon sysfs /devices/platform/soc/75b9000.i2c/i2c-11/11-0025/power_supply/typec/type                                                        u:object_r:sysfs_batteryinfo:s0


### PR DESCRIPTION
This is needed because the `charger` and `healthd` services will try to access it.
`sysfs_batteryinfo` should be strict enough.