### PR TITLE
Move /sys/bus/esoc label to common sepolicy

### DIFF
--- a/sepolicy_platform/genfs_contexts
+++ b/sepolicy_platform/genfs_contexts
@@ -1,5 +1,3 @@
-genfscon sysfs /bus/esoc/devices                                                 u:object_r:sysfs_msm_subsys:s0
-
 genfscon sysfs /module/bcmdhd/parameters/firmware_path                           u:object_r:sysfs_wlan_fwpath:s0
 
 genfscon sysfs /devices/platform/soc/900000.qcom,mdss_mdp                        u:object_r:sysfs_msm_subsys:s0


### PR DESCRIPTION
Move the definition to common for all platforms. It is the same anyway(except for tama, which doesn't have it).
Has to do with my wish to convert it to `sysfs_bus_esoc`, see https://github.com/sonyxperiadev/device-sony-sepolicy/compare/master...ix5:broad-updates?expand=1#diff-b853b8c814752e09883fb398afe7d1a0R68

Happy to discuss