### PR TITLE
[tone] Board sepolicy: Fix legacy build variable

### DIFF
--- a/PlatformConfig.mk
+++ b/PlatformConfig.mk
@@ -67,7 +67,7 @@ BOARD_CUSTOM_BT_CONFIG := $(PLATFORM_COMMON_PATH)/bluetooth/vnd_generic.txt
 TARGET_PER_MGR_ENABLED := true
 
 # SELinux
-BOARD_SEPOLICY_DIRS += $(PLATFORM_COMMON_PATH)/sepolicy_platform
+BOARD_VENDOR_SEPOLICY_DIRS += $(PLATFORM_COMMON_PATH)/sepolicy_platform
 
 # Display
 TARGET_USES_GRALLOC1 := true


### PR DESCRIPTION
Rename BOARD_SEPOLICY_DIRS to BOARD_VENDOR_SEPOLICY_DIRS
for the vendor/ subfolder.

This is needed for split sepolicy compatibility.

See system/sepolicy/Android.mk:
> BOARD_SEPOLICY_DIRS was used for vendor/odm sepolicy customization before.
> It has been replaced by BOARD_VENDOR_SEPOLICY_DIRS (mandatory) and
> BOARD_ODM_SEPOLICY_DIRS (optional). BOARD_SEPOLICY_DIRS is still allowed for
> backward compatibility, which will be merged into BOARD_VENDOR_SEPOLICY_DIRS.
ifdef BOARD_SEPOLICY_DIRS
BOARD_VENDOR_SEPOLICY_DIRS += $(BOARD_SEPOLICY_DIRS)
endif