### PR TITLE
rootdir: init: Setup restart levels for subsystems

### DIFF
--- a/rootdir/vendor/etc/init/init.tone.rc
+++ b/rootdir/vendor/etc/init/init.tone.rc
@@ -28,5 +28,18 @@ on boot
     # to one of the CPU from the default IRQ affinity mask.
     write /proc/irq/default_smp_affinity 3
 
+on init
+    # set up correct restart levels for subsystems
+    # venus
+    write /sys/devices/platform/soc/ce0000.qcom,venus/subsys0/restart_level RELATED
+    # kgsl-hyp
+    write /sys/devices/platform/soc/soc:qcom,kgsl-hyp/subsys1/restart_level RELATED
+    # lpass
+    write /sys/devices/platform/soc/9300000.qcom,lpass/subsys2/restart_level RELATED
+    # ssc
+    write /sys/devices/platform/soc/1c00000.qcom,ssc/subsys3/restart_level RELATED
+    # mss
+    write /sys/devices/platform/soc/2080000.qcom,mss/subsys4/restart_level RELATED
+
 on property:bluetooth.isEnabled=true
     write /sys/class/bluetooth/hci0/idle_timeout 7000


### PR DESCRIPTION
This avoids crashing the whole system when one of the subsystems
crashes.