### PR TITLE
sepolicy_platform: Label kgsl-hyp subsystem

### DIFF
--- a/sepolicy_platform/genfs_contexts
+++ b/sepolicy_platform/genfs_contexts
@@ -3,6 +3,7 @@ genfscon sysfs /module/bcmdhd/parameters/firmware_path                          
 genfscon sysfs /devices/platform/soc/900000.qcom,mdss_mdp                        u:object_r:sysfs_msm_subsys:s0
 genfscon sysfs /devices/platform/soc/900000.qcom,mdss_rotator                    u:object_r:sysfs_msm_subsys:s0
 genfscon sysfs /devices/platform/soc/b00000.qcom,kgsl-3d0                        u:object_r:sysfs_msm_subsys:s0
+genfscon sysfs /devices/platform/soc/soc:qcom,kgsl-hyp                           u:object_r:sysfs_msm_subsys:s0
 genfscon sysfs /devices/platform/soc/9300000.qcom,lpass                          u:object_r:sysfs_msm_subsys:s0
 genfscon sysfs /devices/platform/soc/2080000.qcom,mss                            u:object_r:sysfs_msm_subsys:s0
 genfscon sysfs /devices/platform/soc/400f000.qcom,spmi                           u:object_r:sysfs_msm_subsys:s0


### PR DESCRIPTION
Needed to set correct restart levels.