### PR TITLE
ueventd.rc: Set system user on rgb led pause timings.

### DIFF
--- a/rootdir/vendor/ueventd.rc
+++ b/rootdir/vendor/ueventd.rc
@@ -139,6 +139,8 @@
 /sys/devices/platform/soc/400f000.qcom,spmi/spmi-0/spmi0-03/400f000.qcom,spmi:pmi8994@3:qcom,leds@d000/leds/led:*  brightness      0664  system  system
 /sys/devices/platform/soc/400f000.qcom,spmi/spmi-0/spmi0-03/400f000.qcom,spmi:pmi8994@3:qcom,leds@d000/leds/led:*  blink           0664  system  system
 /sys/devices/platform/soc/400f000.qcom,spmi/spmi-0/spmi0-03/400f000.qcom,spmi:pmi8994@3:qcom,leds@d000/leds/led:*  duty_pcts       0664  system  system
+/sys/devices/platform/soc/400f000.qcom,spmi/spmi-0/spmi0-03/400f000.qcom,spmi:pmi8994@3:qcom,leds@d000/leds/led:*  pause_lo        0664  system  system
+/sys/devices/platform/soc/400f000.qcom,spmi/spmi-0/spmi0-03/400f000.qcom,spmi:pmi8994@3:qcom,leds@d000/leds/led:*  pause_hi        0664  system  system
 /sys/devices/platform/soc/400f000.qcom,spmi/spmi-0/spmi0-03/400f000.qcom,spmi:pmi8994@3:qcom,leds@d000/leds/rgb    rgb_blink       0664  system  system
 
 # Framebuffer for Dynamic Resolution Switch


### PR DESCRIPTION
These timings are used to control the on and off duration of the blink
led.

For sonyxperiadev/device-sony-common/pull/559.