### PR TITLE
[TONE] audio_platform_info: Disable ACDB for OUT_BT_SCO_WB

### DIFF
--- a/rootdir/vendor/etc/audio_platform_info.xml
+++ b/rootdir/vendor/etc/audio_platform_info.xml
@@ -31,6 +31,7 @@
         <!-- Custom mapping starts here -->
         <device name="SND_DEVICE_OUT_VOICE_SPEAKER" acdb_id="101"/>
         <device name="SND_DEVICE_OUT_VOICE_HANDSET" acdb_id="7"/>
+        <device name="SND_DEVICE_OUT_BT_SCO_WB" acdb_id="-1"/>
         <device name="SND_DEVICE_IN_HANDSET_MIC" acdb_id="4"/>
         <device name="SND_DEVICE_IN_VOICE_SPEAKER_MIC" acdb_id="11" />
         <device name="SND_DEVICE_IN_CAMCORDER_MIC" acdb_id="544"/>


### PR DESCRIPTION
The entry for this calibration seems to be badly read or
corrupted: that makes it the kernel to send a Q6 CVP
parameter that is setting 15 RX channels and that is
obviously ... wrong.

Disable the ACDB calibration for the BT SCO WB device
at least until the database gets eventually fixed.

This PR fixes in-call BT audio