### PR TITLE
[master] PlatformConfig: Add restore_msm_uart early parameter

### DIFF
--- a/PlatformConfig.mk
+++ b/PlatformConfig.mk
@@ -39,7 +39,7 @@ BOARD_RAMDISK_OFFSET     := 0x02000000
 BOARD_KERNEL_CMDLINE += androidboot.bootdevice=7464900.sdhci
 
 # Serial console
-#BOARD_KERNEL_CMDLINE += earlycon=msm_serial_dm,0x075b0000
+#BOARD_KERNEL_CMDLINE += earlycon=msm_serial_dm,0x075b0000 restore_msm_uart=0x01014000
 
 TARGET_RECOVERY_FSTAB ?= $(PLATFORM_COMMON_PATH)/rootdir/vendor/etc/fstab.tone
 


### PR DESCRIPTION
Add an early parameter which activates an early function that will
restore the correct pin configuration in the TLMM block on the
UART_TX and UART_RX GPIOs. This will bring back access to the
early console.

Tone platform:
    TLMM start: 0x01010000
    UART TX: GPIO4
    UART TX OFFSET: 0x4000

Reference to: sonyxperiadev/kernel#1907

Signed-off-by: Pavel Dubrova <pashadubrova@gmail.com>