### PR TITLE
[TONE] rqbalance: Allow more computational power

### DIFF
--- a/rootdir/vendor/etc/rqbalance_config.xml
+++ b/rootdir/vendor/etc/rqbalance_config.xml
@@ -18,8 +18,8 @@
     <batterysave>
         <cpuquiet min_cpus="1" max_cpus="2"/>
         <rqbalance balance_level="80"/>
-        <rqbalance down_thresholds="0 120 200 330 4294967295 4294967295 4294967295 4294967295"/>
-        <rqbalance   up_thresholds="180 240 400 4294967295 4294967295 4294967295 4294967295 4294967295"/>
+        <rqbalance down_thresholds="0 80 200 330 4294967295 4294967295 4294967295 4294967295"/>
+        <rqbalance   up_thresholds="140 240 400 4294967295 4294967295 4294967295 4294967295 4294967295"/>
         <rqbalance cluster0_freq_min="0"/>
         <rqbalance cluster0_freq_max="1324800"/>
         <rqbalance cluster1_freq_min="0"/>
@@ -30,7 +30,7 @@
         <cpuquiet min_cpus="2" max_cpus="4"/>
         <rqbalance balance_level="40"/>
         <rqbalance down_thresholds="0 35 95 160 4294967295 4294967295 4294967295 4294967295"/>
-        <rqbalance   up_thresholds="65 145 300 4294967295 4294967295 4294967295 4294967295 4294967295"/>
+        <rqbalance   up_thresholds="65 120 225 4294967295 4294967295 4294967295 4294967295 4294967295"/>
     </balanced>
 
     <performance>


### PR DESCRIPTION
This platform is very weak: two CPUs aren't going to make the
day at all.
Allow more computational power on the balanced profile and be
less restrictive on the powersave one, where the device would
be too slow to be usable with just a single core.