### PR TITLE
[TONE] platform: Disable SDE composition by forcing no blend

### DIFF
--- a/platform.mk
+++ b/platform.mk
@@ -149,6 +149,10 @@ PRODUCT_PROPERTY_OVERRIDES += \
     ro.qti.sensors.als_scale=1 \
     ro.qfusion_use_report_period=false
 
+# Display HACK: Use GPU composition only
+PRODUCT_PROPERTY_OVERRIDES += \
+    vendor.display.primary_mixer_stages=1
+
 # USB controller setup
 PRODUCT_PROPERTY_OVERRIDES += \
     sys.usb.controller=6a00000.dwc3 \


### PR DESCRIPTION
Set primary mixer stages to 1 to force getting no blend
support from the display HAL.
This switches us from the SDE composition to the GPU
composition, which is a hack that is required for legacy
platforms on the SDE driver because of a severe
incompatibility with the current blobs.

There are no barriers because the FBDEV driver-HAL
combo have no blobs to support the SDM composition
and this configuration is anyway already doing what we
are forcing there.