### PR TITLE
[TEMP] platform: add property to skip loading libsdmextension

### DIFF
--- a/platform.mk
+++ b/platform.mk
@@ -150,8 +150,10 @@ PRODUCT_PROPERTY_OVERRIDES += \
     ro.qfusion_use_report_period=false
 
 # Display HACK: Use GPU composition only
+## TEMP: Skip loading libsdmextension.so in display hal
 PRODUCT_PROPERTY_OVERRIDES += \
     vendor.display.primary_mixer_stages=1
+    vendor.display.skip_extension_intf=1
 
 # USB controller setup
 PRODUCT_PROPERTY_OVERRIDES += \


### PR DESCRIPTION
Loading the extension library fails because it can not find libscalar.so, which is indeed not provided.
This leads to failure when initializing the display hal.
Since the extension interface is not critically required on tone while still not switched to DRM, skip it.
This commit MUST be reverted after switching to DRM, because then the extension interface is critical for clocks managment.