### PR TITLE
sepolicy: label brcmfmac mac_adress 1/2

### DIFF
--- a/sepolicy_platform/genfs_contexts
+++ b/sepolicy_platform/genfs_contexts
@@ -1,4 +1,4 @@
-genfscon sysfs /module/bcmdhd/parameters/firmware_path                           u:object_r:sysfs_wlan_fwpath:s0
+genfscon sysfs /devices/platform/soc/600000.pcie/pci0000:00/0000:00:00.0/0000:01:00.0/net/wlan0/address     u:object_r:sysfs_mac_address:s0
 
 genfscon sysfs /devices/platform/soc/900000.qcom,mdss_mdp                        u:object_r:sysfs_msm_subsys:s0
 genfscon sysfs /devices/platform/soc/900000.qcom,mdss_rotator                    u:object_r:sysfs_msm_subsys:s0


### PR DESCRIPTION
04-12 17:11:11.742  3306  3306 I Binder:3306_2: type=1400 audit(0.0:21): avc: denied { read } for name=address dev=sysfs ino=50814 scontext=u:r:priv_app:s0:c512,c768 tcontext=u:object_r:sysfs:s0 tclass=file permissive=1
04-12 17:11:11.742  3306  3306 I Binder:3306_2: type=1400 audit(0.0:22): avc: denied { open } for path=/sys/devices/platform/soc/600000.pcie/pci0000:00/0000:00:00.0/0000:01:00.0/net/wlan0/address dev=sysfs ino=50814 scontext=u:r:priv_app:s0:c512,c768 tcontext=u:object_r:sysfs:s0 tclass=file permissive=1
04-12 17:11:11.742  3306  3306 I Binder:3306_2: type=1400 audit(0.0:23): avc: denied { getattr } for path=/sys/devices/platform/soc/600000.pcie/pci0000:00/0000:00:00.0/0000:01:00.0/net/wlan0/address dev=sysfs ino=50814 scontext=u:r:priv_app:s0:c512,c768 tcontext=u:object_r:sysfs:s0 tclass=file permissive=1

Signed-off-by: David Viteri <davidteri91@gmail.com>