### PR TITLE
FIX] platform.mk: Define kernel vars before common.mk

### DIFF
--- a/platform.mk
+++ b/platform.mk
@@ -15,13 +15,13 @@
 # Platform path
 PLATFORM_COMMON_PATH := device/sony/tone
 
-$(call inherit-product, device/sony/common/common.mk)
-$(call inherit-product, $(SRC_TARGET_DIR)/product/core_64_bit.mk)
-$(call inherit-product, hardware/broadcom/wlan/bcmdhd/config/config-bcm.mk)
-
 SOMC_PLATFORM := tone
 SOMC_KERNEL_VERSION := 4.9
 KERNEL_PATH := kernel/sony/msm-$(SOMC_KERNEL_VERSION)
+
+$(call inherit-product, device/sony/common/common.mk)
+$(call inherit-product, $(SRC_TARGET_DIR)/product/core_64_bit.mk)
+$(call inherit-product, hardware/broadcom/wlan/bcmdhd/config/config-bcm.mk)
 
 SONY_ROOT := $(PLATFORM_COMMON_PATH)/rootdir
 


### PR DESCRIPTION
The `KERNEL_PATH` buildvar needs to be set before `common.mk` can be inherited.