### PR TITLE
overlay: Don't send mic_mute to AudioManager

### DIFF
--- a/overlay/packages/services/Telephony/res/values/config.xml
+++ b/overlay/packages/services/Telephony/res/values/config.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--Copyright (c) 2012, The Linux Foundation. All rights reserved.
+
+    Not a Contribution, Apache license notifications and license are retained
+    for attribution purposes only.
+
+    Licensed under the Apache License, Version 2.0 (the "License"); you
+    may not use this file except in compliance with the License.  You may
+    obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+    implied.  See the License for the specific language governing
+    permissions and limitations under the License.
+-->
+
+<!-- Phone app resources that may need to be customized
+     for different hardware or product builds. -->
+<resources>
+    <!-- Determine whether calls to mute the microphone in PhoneUtils
+         are routed through the android.media.AudioManager class (true) or through
+         the com.android.internal.telephony.Phone interface (false).
+
+         Disabled due to errors on tone (mic_mute not implemented)
+     -->
+    <bool name="send_mic_mute_to_AudioManager">false</bool>
+
+</resources>


### PR DESCRIPTION
It seems the functionality is broken since there's errors in logcat about a not implemented mic_mute function.

Mabye `AudioManager` can now handle this case.