### PR TITLE
[VERIFYME] init: Limit MTP rx/tx buffers to 16384

### DIFF
--- a/rootdir/vendor/etc/init/init.tone.rc
+++ b/rootdir/vendor/etc/init/init.tone.rc
@@ -38,6 +38,12 @@ on boot
     # to one of the CPU from the default IRQ affinity mask.
     write /proc/irq/default_smp_affinity 3
 
+    # MTP kernel parameters - needed so that swiotlb does not run OOM
+    chown system system /sys/module/usb_f_mtp/parameters/mtp_rx_req_len
+    chown system system /sys/module/usb_f_mtp/parameters/mtp_tx_req_len
+    write /sys/module/usb_f_mtp/parameters/mtp_rx_req_len 16384
+    write /sys/module/usb_f_mtp/parameters/mtp_tx_req_len 16384
+
 on property:bluetooth.isEnabled=true
     write /sys/class/bluetooth/hci0/idle_timeout 7000
 


### PR DESCRIPTION
Limit MTP_RX_BUFFER_INIT_SIZE and MTP_TX_BUFFER_INIT_SIZE from 1048576 to 16384

Should fix swiotlb running OOM with large file transfers.

See https://github.com/sonyxperiadev/bug_tracker/issues/432#issuecomment-517964636

Needs accompanying sepolicy.