### PR TITLE
audio_platform_info: Disable ACDB for OUT_BT_SCO

### DIFF
--- a/rootdir/vendor/etc/audio_platform_info.xml
+++ b/rootdir/vendor/etc/audio_platform_info.xml
@@ -31,6 +31,7 @@
         <!-- Custom mapping starts here -->
         <device name="SND_DEVICE_OUT_VOICE_SPEAKER" acdb_id="101"/>
         <device name="SND_DEVICE_OUT_VOICE_HANDSET" acdb_id="7"/>
+        <device name="SND_DEVICE_OUT_BT_SCO" acdb_id="-1"/>
         <device name="SND_DEVICE_OUT_BT_SCO_WB" acdb_id="-1"/>
         <device name="SND_DEVICE_IN_HANDSET_MIC" acdb_id="4"/>
         <device name="SND_DEVICE_IN_VOICE_SPEAKER_MIC" acdb_id="11" />


### PR DESCRIPTION
For https://github.com/sonyxperiadev/bug_tracker/issues/509

Much like OUT_BT_SCO_WB, the acdb entry for OUT_BT_SCO contains a bogus
number of TX channels that break in the DSP, leading to no audio in
voice calls. Disabling this calibration gives an appropriate and working
default configuration.

While not being confirmed that the _TX_ channels (not RX) were exactly
15, they were something other than 1; the reporter confirmed that
forcing this value back to 1 (exactly how the _WB issue was initially
solved: https://sx.ix5.org/info/post/bluetooth-audio-debugging/ fixes
the issue here as well).
For completeness, see the commit message from the OUT_BT_SCO_WB
disablement:

> The entry for this calibration seems to be badly read or
> corrupted: that makes it the kernel to send a Q6 CVP
> parameter that is setting 15 RX channels and that is
> obviously ... wrong.
>
> Disable the ACDB calibration for the BT SCO WB device
> at least until the database gets eventually fixed.

Signed-off-by: MarijnS95 <marijns95@gmail.com>