### PR TITLE
[WIP] Change remaining bcmdhd refs to brcmfmac

### DIFF
--- a/platform.mk
+++ b/platform.mk
@@ -20,7 +20,6 @@ SOMC_KERNEL_VERSION := 4.9
 
 $(call inherit-product, device/sony/common/common.mk)
 $(call inherit-product, $(SRC_TARGET_DIR)/product/core_64_bit.mk)
-$(call inherit-product, hardware/broadcom/wlan/bcmdhd/config/config-bcm.mk)
 
 SONY_ROOT := $(PLATFORM_COMMON_PATH)/rootdir
 
@@ -178,7 +177,7 @@ PRODUCT_PROPERTY_OVERRIDES += \
 
 # WiFi MAC address path
 PRODUCT_PROPERTY_OVERRIDES += \
-    ro.vendor.wifi.addr_path=/sys/devices/platform/soc/soc:bcmdhd_wlan/macaddr
+    ro.vendor.wifi.addr_path=/sys/devices/platform/soc/soc:brcmfmac/macaddr
 
 # setup dm-verity configs.
 PRODUCT_SYSTEM_VERITY_PARTITION := /dev/block/platform/soc/7464900.sdhci/by-name/system

--- a/rootdir/vendor/etc/init/init.tone.rc
+++ b/rootdir/vendor/etc/init/init.tone.rc
@@ -24,8 +24,8 @@ on init
 
 on boot
     # WLAN and BT MAC
-    chown system system /sys/devices/platform/soc/soc:bcmdhd_wlan/macaddr
-    chown wifi wifi /sys/module/bcmdhd/parameters/firmware_path
+    chown system system /sys/devices/platform/soc/soc:brcmfmac/macaddr
+    chown wifi wifi /sys/module/brcmfmac/parameters/firmware_path
 
     # update foreground cpuset now that processors are up
     write /dev/cpuset/foreground/cpus 0-3

--- a/sepolicy_platform/genfs_contexts
+++ b/sepolicy_platform/genfs_contexts
@@ -1,5 +1,7 @@
 genfscon sysfs /devices/platform/soc/600000.pcie/pci0000:00/0000:00:00.0/0000:01:00.0/net/wlan0/address     u:object_r:sysfs_mac_address:s0
 
+genfscon sysfs /module/brcmfmac/parameters/firmware_path                         u:object_r:sysfs_wlan_fwpath:s0
+
 genfscon sysfs /devices/platform/soc/900000.qcom,mdss_mdp                        u:object_r:sysfs_msm_subsys:s0
 genfscon sysfs /devices/platform/soc/900000.qcom,mdss_rotator                    u:object_r:sysfs_msm_subsys:s0
 genfscon sysfs /devices/platform/soc/b00000.qcom,kgsl-3d0                        u:object_r:sysfs_msm_subsys:s0
@@ -18,7 +20,7 @@ genfscon sysfs /devices/platform/soc/aa0000.qcom,jpeg                           
 genfscon sysfs /devices/platform/soc/8c0000.qcom,msm-cam                         u:object_r:sysfs_camera:s0
 
 genfscon sysfs /devices/platform/soc/soc:bcm43xx/rfkill/rfkill0/state            u:object_r:sysfs_bluetooth:s0
-genfscon sysfs /devices/platform/soc/soc:bcmdhd_wlan/macaddr                     u:object_r:sysfs_addrsetup:s0
+genfscon sysfs /devices/platform/soc/soc:brcmfmac/macaddr                        u:object_r:sysfs_addrsetup:s0
 genfscon sysfs /devices/platform/soc/soc:fpc1145                                 u:object_r:sysfs_fingerprint:s0
 
 genfscon sysfs /devices/platform/soc/900000.qcom,mdss_mdp/caps                   u:object_r:sysfs_mdss_mdp_caps:s0


### PR DESCRIPTION
The transition of the wlan driver from bcmdhd to brcmfmac is complete as of kernel 4.9.

Fix references: `wifi.addr_path`, sepolicy_platform sysfs labels, add `sysfs_wlan_path` label, `chowns` in init for sysfs nodes.