### PR TITLE
platform: Relax inheritance on broadcom wlan repo

### DIFF
--- a/platform.mk
+++ b/platform.mk
@@ -208,4 +208,4 @@ PRODUCT_SYSTEM_VERITY_PARTITION := /dev/block/platform/soc/7464900.sdhci/by-name
 $(call inherit-product, build/target/product/verity.mk)
 $(call inherit-product, device/sony/common/common.mk)
 $(call inherit-product, $(SRC_TARGET_DIR)/product/core_64_bit.mk)
-$(call inherit-product, hardware/broadcom/wlan/bcmdhd/config/config-bcm.mk)
+$(call inherit-product-if-exists, hardware/broadcom/wlan/bcmdhd/config/config-bcm.mk)


### PR DESCRIPTION
The config-bcm.mk makefile in hardware/broadcom/wlan will potentially overwrite our own configs.
Handle a nonexistent repo gracefully by using `inherit-product-if-exists`.