### PR TITLE
platform: Move several vars into platform.mk

### DIFF
--- a/PlatformConfig.mk
+++ b/PlatformConfig.mk
@@ -12,12 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Platform path
-PLATFORM_COMMON_PATH := device/sony/tone
-PRODUCT_PLATFORM_SOD := true
-
-TARGET_BOARD_PLATFORM := msm8996
-
 TARGET_ARCH := arm64
 TARGET_ARCH_VARIANT := armv8-a
 TARGET_CPU_ABI := arm64-v8a
@@ -42,31 +36,8 @@ BOARD_KERNEL_CMDLINE += androidboot.bootdevice=7464900.sdhci
 
 TARGET_RECOVERY_FSTAB ?= $(PLATFORM_COMMON_PATH)/rootdir/vendor/etc/fstab.tone
 
-# Wi-Fi definitions for Broadcom solution but using brcmfmac instead of bcmdhd kernel driver
-BOARD_WLAN_DEVICE           := qcwcn
-BOARD_WPA_SUPPLICANT_DRIVER := NL80211
-WPA_SUPPLICANT_VERSION      := VER_0_8_X
-BOARD_WPA_SUPPLICANT_PRIVATE_LIB := lib_driver_cmd_qcwcn
-BOARD_HOSTAPD_DRIVER        := NL80211
-BOARD_HOSTAPD_PRIVATE_LIB   := lib_driver_cmd_qcwcn
-
-# BT definitions for Broadcom solution
-BOARD_BLUETOOTH_BDROID_BUILDCFG_INCLUDE_DIR := $(PLATFORM_COMMON_PATH)/bluetooth
-BOARD_HAVE_BLUETOOTH := true
-BOARD_HAVE_BLUETOOTH_BCM := true
-BOARD_CUSTOM_BT_CONFIG := $(PLATFORM_COMMON_PATH)/bluetooth/vnd_generic.txt
-
-# TAD
-TARGET_USES_TAD_V2 := true
-
-# RIL
-TARGET_PER_MGR_ENABLED := true
-
 # SELinux
 BOARD_VENDOR_SEPOLICY_DIRS += $(PLATFORM_COMMON_PATH)/sepolicy_platform
-
-# Display
-TARGET_USES_GRALLOC1 := true
 
 # Cache partition
 BOARD_CACHEIMAGE_FILE_SYSTEM_TYPE := ext4

--- a/platform.mk
+++ b/platform.mk
@@ -18,11 +18,34 @@ PLATFORM_COMMON_PATH := device/sony/tone
 SOMC_PLATFORM := tone
 SOMC_KERNEL_VERSION := 4.9
 
-$(call inherit-product, device/sony/common/common.mk)
-$(call inherit-product, $(SRC_TARGET_DIR)/product/core_64_bit.mk)
-$(call inherit-product, hardware/broadcom/wlan/bcmdhd/config/config-bcm.mk)
+PRODUCT_PLATFORM_SOD := true
+
+TARGET_BOARD_PLATFORM := msm8996
 
 SONY_ROOT := $(PLATFORM_COMMON_PATH)/rootdir
+
+# Wi-Fi definitions for Broadcom solution but using brcmfmac instead of bcmdhd kernel driver
+BOARD_WLAN_DEVICE           := qcwcn
+BOARD_WPA_SUPPLICANT_DRIVER := NL80211
+WPA_SUPPLICANT_VERSION      := VER_0_8_X
+BOARD_WPA_SUPPLICANT_PRIVATE_LIB := lib_driver_cmd_qcwcn
+BOARD_HOSTAPD_DRIVER        := NL80211
+BOARD_HOSTAPD_PRIVATE_LIB   := lib_driver_cmd_qcwcn
+
+# BT definitions for Broadcom solution
+BOARD_BLUETOOTH_BDROID_BUILDCFG_INCLUDE_DIR := $(PLATFORM_COMMON_PATH)/bluetooth
+BOARD_HAVE_BLUETOOTH := true
+BOARD_HAVE_BLUETOOTH_BCM := true
+BOARD_CUSTOM_BT_CONFIG := $(PLATFORM_COMMON_PATH)/bluetooth/vnd_generic.txt
+
+# TAD
+TARGET_USES_TAD_V2 := true
+
+# RIL
+TARGET_PER_MGR_ENABLED := true
+
+# Display
+TARGET_USES_GRALLOC1 := true
 
 # Overlay
 DEVICE_PACKAGE_OVERLAYS += \
@@ -183,3 +206,6 @@ PRODUCT_PROPERTY_OVERRIDES += \
 # setup dm-verity configs.
 PRODUCT_SYSTEM_VERITY_PARTITION := /dev/block/platform/soc/7464900.sdhci/by-name/system
 $(call inherit-product, build/target/product/verity.mk)
+$(call inherit-product, device/sony/common/common.mk)
+$(call inherit-product, $(SRC_TARGET_DIR)/product/core_64_bit.mk)
+$(call inherit-product, hardware/broadcom/wlan/bcmdhd/config/config-bcm.mk)


### PR DESCRIPTION
Defining these variables earlier means we can make use of
them in `$(inherit)`-ed lowercase makefiles.

Also, move the include of common.mk to the end of the file,
so that common.mk can make use of the variables defined
above.